### PR TITLE
Rename TImageGenParams by TImageCreateParams

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Given a prompt and/or an input image, the model will generate a new image.
 
 ```Pascal
 var Images := OpenAI.Image.Create(
-  procedure(Params: TImageGenParams)
+  procedure(Params: TImageCreateParams)
   begin
     Params.Prompt(MemoPrompt.Text);
     Params.ResponseFormat('url');


### PR DESCRIPTION
Rename TImageGenParams by TImageCreateParams. If I am not wrong, this is simply typo or maybe the renamed type exists in the past.