### PR TITLE
Feature/usage of azure api

### DIFF
--- a/OpenAI.Images.pas
+++ b/OpenAI.Images.pas
@@ -237,9 +237,6 @@ type
 
 implementation
 
-uses
-  Winapi.Windows;
-
 { TImagesRoute }
 
 function TImagesRoute.Create(ParamProc: TProc<TImageCreateParams>): TImageGenerations;
@@ -465,7 +462,7 @@ begin
   if (Result.ID = '') or (Result.Status = 'Failed') then
     exit;
 
-  StartTime := GetTickCount64;
+  StartTime := TThread.GetTickCount64;
 
   // Repeat GET requesting the operations-endpoint until we have a "succeeded" response
   while true do
@@ -479,7 +476,7 @@ begin
 
     // Check timeout - current documentation is not precise what to expect when the state is "inProgress"
     // but the result at this point should contain all relevant information
-    ElapsedTime := GetTickCount64 - StartTime;
+    ElapsedTime := TThread.GetTickCount64 - StartTime;
     if ElapsedTime > Timeout then
       exit;
 

--- a/OpenAI.pas
+++ b/OpenAI.pas
@@ -2,11 +2,9 @@
 
 interface
 
-uses
-  System.SysUtils, System.Classes, OpenAI.Completions, OpenAI.Edits,
-  OpenAI.Images, OpenAI.Models, OpenAI.Embeddings, OpenAI.API,
-  OpenAI.Moderations, OpenAI.Engines, OpenAI.Files, OpenAI.FineTunes,
-  OpenAI.Chat, OpenAI.Audio;
+uses System.SysUtils, System.Classes, OpenAI.Completions, OpenAI.Edits, OpenAI.Images,
+  OpenAI.Models, OpenAI.Embeddings, OpenAI.API, OpenAI.Moderations, OpenAI.Engines, OpenAI.Files,
+  OpenAI.FineTunes, OpenAI.Chat, OpenAI.Audio;
 
 type
   IOpenAI = interface
@@ -134,6 +132,12 @@ type
     function GetFineTunesRoute: TFineTunesRoute;
     function GetChatRoute: TChatRoute;
     function GetAudioRoute: TAudioRoute;
+    function GetAzureAPIVersion: string;
+    function GetAzureDeployment: string;
+    function GetIsAzure: Boolean;
+    procedure SetAzureAPIVersion(const Value: string);
+    procedure SetAzureDeployment(const Value: string);
+    procedure SetIsAzure(const Value: Boolean);
   public
     constructor Create; overload;
     constructor Create(const AToken: string); overload;
@@ -161,6 +165,10 @@ type
     // subscription quota.
     /// </summary>
     property Organization: string read GetOrganization write SetOrganization;
+
+    property IsAzure: Boolean read GetIsAzure write SetIsAzure;
+    property AzureApiVersion: string read GetAzureAPIVersion write SetAzureAPIVersion;
+    property AzureDeployment: string read GetAzureDeployment write SetAzureDeployment;
   public
     /// <summary>
     /// Given a prompt, the model will return one or more predicted completions,
@@ -368,9 +376,19 @@ begin
   Result := FAudioRoute;
 end;
 
+function TOpenAI.GetAzureAPIVersion: string;
+begin
+  Result := FAPI.AzureApiVersion;
+end;
+
+function TOpenAI.GetAzureDeployment: string;
+begin
+  Result := FAPI.AzureDeployment;
+end;
+
 function TOpenAI.GetBaseUrl: string;
 begin
-  Result := FAPI.BaseUrl;
+  Result := FAPI.BaseURL;
 end;
 
 function TOpenAI.GetChatRoute: TChatRoute;
@@ -429,6 +447,11 @@ begin
   Result := FImagesRoute;
 end;
 
+function TOpenAI.GetIsAzure: Boolean;
+begin
+  Result := FAPI.IsAzure;
+end;
+
 function TOpenAI.GetModelsRoute: TModelsRoute;
 begin
   if not Assigned(FModelsRoute) then
@@ -453,9 +476,24 @@ begin
   Result := FAPI.Token;
 end;
 
+procedure TOpenAI.SetAzureAPIVersion(const Value: string);
+begin
+  FAPI.AzureApiVersion := Value;
+end;
+
+procedure TOpenAI.SetAzureDeployment(const Value: string);
+begin
+  FAPI.AzureDeployment := Value;
+end;
+
 procedure TOpenAI.SetBaseUrl(const Value: string);
 begin
-  FAPI.BaseUrl := Value;
+  FAPI.BaseURL := Value;
+end;
+
+procedure TOpenAI.SetIsAzure(const Value: Boolean);
+begin
+  FAPI.IsAzure := Value;
 end;
 
 procedure TOpenAI.SetOrganization(const Value: string);
@@ -573,4 +611,3 @@ begin
 end;
 
 end.
-

--- a/OpenAI.pas
+++ b/OpenAI.pas
@@ -106,6 +106,7 @@ type
     FCompletionsRoute: TCompletionsRoute;
     FEditsRoute: TEditsRoute;
     FImagesRoute: TImagesRoute;
+    FImagesAzureRoute: TImagesAzureRoute;
     FModelsRoute: TModelsRoute;
     FEmbeddingsRoute: TEmbeddingsRoute;
     FModerationsRoute: TModerationsRoute;
@@ -138,6 +139,7 @@ type
     procedure SetAzureAPIVersion(const Value: string);
     procedure SetAzureDeployment(const Value: string);
     procedure SetIsAzure(const Value: Boolean);
+    function GetImagesAzureRoute: TImagesAzureRoute;
   public
     constructor Create; overload;
     constructor Create(const AToken: string); overload;
@@ -183,6 +185,10 @@ type
     /// Given a prompt and/or an input image, the model will generate a new image.
     /// </summary>
     property Image: TImagesRoute read GetImagesRoute;
+    /// <summary>
+    /// Given a prompt and/or an input image, the model will generate a new image.
+    /// </summary>
+    property ImageAzure: TImagesAzureRoute read GetImagesAzureRoute;
     /// <summary>
     /// List and describe the various models available in the API.
     /// You can refer to the Models documentation to understand what models are available and the differences between them.
@@ -344,6 +350,8 @@ begin
     FEditsRoute.Free;
   if Assigned(FImagesRoute) then
     FImagesRoute.Free;
+  if Assigned(FImagesAzureRoute) then
+    FImagesAzureRoute.Free;
   if Assigned(FModelsRoute) then
     FModelsRoute.Free;
   if Assigned(FEmbeddingsRoute) then
@@ -438,6 +446,13 @@ begin
   if not Assigned(FFineTunesRoute) then
     FFineTunesRoute := TFineTunesRoute.CreateRoute(API);
   Result := FFineTunesRoute;
+end;
+
+function TOpenAI.GetImagesAzureRoute: TImagesAzureRoute;
+begin
+  if not Assigned(FImagesAzureRoute) then
+    FImagesAzureRoute := TImagesAzureRoute.CreateRoute(API);
+  Result := FImagesAzureRoute;
 end;
 
 function TOpenAI.GetImagesRoute: TImagesRoute;


### PR DESCRIPTION
Usage of Chat Completion should work with just setting the Azure-Properties. 

Below is an example for the (for now very simple) api call to the dall-E images inside azure. 
Problem was, that this is a 2-request solution inside azure. First request returns an ID, second request has to fetch the operations-endpoint until the result is finished.

```
function SendChatGPTImageRequest(APrompt: string): string;
var
  AImages: TAzureImageResponse;
begin
  AImages := OpenAIObj.Image.CreateAzure(
    procedure(Params: TImageCreateParams)
    begin
      Params.Caption(APrompt);
    end);
  try
    Result := AImages.Result.ContentURL;
  finally
    AImages.Free;
  end;
end;
```

```
  OpenAIObj.BaseURL := 'https://xxxx.openai.azure.com';
  OpenAIObj.IsAzure := true;
  OpenAIObj.AzureApiVersion := '2022-08-03-preview';
  OpenAIObj.AzureDeployment := '<deployment-name>';
  OpenAIObj.Token := 'xxxxxxx';
  AResponse := SendChatGPTImageRequest(ACommand);
```